### PR TITLE
Python 3 support

### DIFF
--- a/pyrestorm/client.py
+++ b/pyrestorm/client.py
@@ -1,7 +1,7 @@
 import json
 import requests
 
-from exceptions.http import (
+from .exceptions.http import (
     ServerErrorException,
     NotFoundException,
     PermissionDeniedException,
@@ -9,7 +9,7 @@ from exceptions.http import (
     BadRequestException,
     MethodNotAllowedException
 )
-from utils import build_url
+from .utils import build_url
 
 
 class StatusCodes(object):

--- a/pyrestorm/models.py
+++ b/pyrestorm/models.py
@@ -7,7 +7,7 @@ from pyrestorm.exceptions import orm as orm_exceptions
 from pyrestorm.query import RestQueryset
 from pyrestorm.manager import RestOrmManager
 
-primitives = [int, str, unicode, bool, type(None)]
+primitives = [int, bytes, str, bool, type(None)]
 non_object_types = [dict, list, tuple]
 
 SENTINEL = '__SENTINEL__'
@@ -36,7 +36,7 @@ class RestModelBase(type):
         # Binds `Field` instances to the meta class for validation
         new_class._meta.fields = {}
         new_class._meta.related_fields = {}
-        for name in attrs.keys():
+        for name in list(attrs.keys()):
             if isinstance(attrs[name], Field):
                 new_class._meta.fields[name] = attrs.pop(name)
                 # Keep track of `RelatedFields` specially
@@ -89,7 +89,7 @@ class RestModel(six.with_metaclass(RestModelBase)):
         self._bind_data(self, data_to_bind)
 
         # Bind to the name of the field a `RestQueryset` of the correct type
-        for name, field in self._meta.related_fields.iteritems():
+        for name, field in self._meta.related_fields.items():
             # Don't rebind data which already exists
             if hasattr(self, self._meta.slug_field) is True:
                 setattr(
@@ -125,7 +125,7 @@ class RestModel(six.with_metaclass(RestModelBase)):
     # Bind the JSON data to the new instance
     @staticmethod
     def _bind_data(obj, data):
-        for key, val in data.iteritems():
+        for key, val in data.items():
             # Bind the data to the next level if need be
             if isinstance(val, dict):
                 # Create the class if need be, otherwise do nothing
@@ -177,7 +177,7 @@ class RestModel(six.with_metaclass(RestModelBase)):
             obj = obj.__dict__
 
         # Check each value in the `dict` for changes
-        for key, value in obj.iteritems():
+        for key, value in obj.items():
             # 0. Private variables: SKIP
             # Escape early if nothing has changed
             if key.startswith('_') or self._get_reference_data(ref, key) == value:
@@ -236,7 +236,7 @@ class RestModel(six.with_metaclass(RestModelBase)):
 
     # Returns the URL to this resource
     def get_absolute_url(self):
-        return self.get_base_url(bits=[unicode(getattr(self, self._meta.slug_field, '')), ])
+        return self.get_base_url(bits=[str(getattr(self, self._meta.slug_field, '')), ])
 
     # Does not save nested keys
     def save(self, raise_exception=False, **kwargs):

--- a/pyrestorm/paginators.py
+++ b/pyrestorm/paginators.py
@@ -9,7 +9,7 @@ class RestPaginator(object):
         # How many records should be retrived per request
         self.page_size = page_size
 
-    def next(self):
+    def __next__(self):
         '''Advances the cursor to the next valid location, if available.
 
         Returns:
@@ -66,7 +66,7 @@ class DjangoRestFrameworkLimitOffsetPaginator(RestPaginator):
         return super(DjangoRestFrameworkLimitOffsetPaginator, self).__init__(page_size=limit, **kwargs)
 
     # Retrieved is meant to educate the paginator on the amount of results retrieved last request
-    def next(self):
+    def __next__(self):
         if not self.page_size or not self.max:
             return False
         # If we don't know how many records there are, and we retrieved a full page last request, next could exist
@@ -101,7 +101,7 @@ class DjangoRestFrameworkLimitOffsetPaginator(RestPaginator):
 
     # Dictionary of URL params for pagination
     def as_params(self):
-        params = {'offset': unicode(self.position)}
+        params = {'offset': str(self.position)}
         if self.page_size is not None:
-            params['limit'] = unicode(self.page_size)
+            params['limit'] = str(self.page_size)
         return params

--- a/pyrestorm/query.py
+++ b/pyrestorm/query.py
@@ -79,7 +79,7 @@ class RestQueryset(object):
             params.update(self._paginator.as_params())
 
         # Sanatize the parameters since some Python types don't encode well
-        for key, value in self.query.params.iteritems():
+        for key, value in self.query.params.items():
             if isinstance(value, (set, frozenset)):
                 value = list(value)
             params[key] = value
@@ -123,7 +123,7 @@ class RestQueryset(object):
             self._count += count
 
             # Determine if we need to grab another round of records
-            fetch = self._paginator.next() if end is None else self._count < (end - start)
+            fetch = next(self._paginator) if end is None else self._count < (end - start)
 
         return self._data
 
@@ -160,7 +160,7 @@ class RestQueryset(object):
         instance = self.model()
 
         # Assign all of the attributes to the model
-        for key, value in kwargs.iteritems():
+        for key, value in kwargs.items():
             setattr(instance, key, value)
 
         # Persist to the API

--- a/pyrestorm/utils.py
+++ b/pyrestorm/utils.py
@@ -1,13 +1,13 @@
 import six
-import urllib
-from urlparse import parse_qsl, urlparse, urlunparse
+import urllib.request, urllib.parse, urllib.error
+from urllib.parse import parse_qsl, urlparse, urlunparse
 
 
 def unicode_to_ascii(item):
     '''Removes non-URL encodable characters(unicode) from the URL.
     '''
     if isinstance(item, dict):
-        for key in item.keys():
+        for key in list(item.keys()):
             if isinstance(item[key], six.string_types):
                 item[key] = item[key].encode('ascii', 'ignore')
 
@@ -20,5 +20,5 @@ def build_url(url, **kwargs):
     parsed_url = list(urlparse(url))
     qs = dict(parse_qsl(parsed_url[4]))
     qs.update(unicode_to_ascii(kwargs))
-    parsed_url[4] = urllib.urlencode(qs)
+    parsed_url[4] = urllib.parse.urlencode(qs)
     return urlunparse(parsed_url)

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,4 +1,4 @@
-[pytest]
+[tool:pytest]
 addopts = --cov pyrestorm
 norecursedirs = .* CVS _darcs {arch} *.egg venv
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,13 +1,15 @@
 [tox]
 downloadcache = {distshare}
 args_are_paths = false
-envlist = {py27}
+envlist = {py27,py39}
 
 [testenv]
 basepython =
     py27: python2.7
+    py39: python3.9
 commands = 
     py.test --cov-report term-missing
 deps =
     pytest
     pytest-cov
+    mock


### PR DESCRIPTION
First shot for Python 3 support: pass 2to3 on the codebase.

Resulted in an importable and working(?) module. Tests fail on name resolution over api.genepeeks.com and I guess this is not a fault of the module. The changes also broke Py2.7. May be possible to have it work by using `futures` module as a compatibility layer. Idk if is worth, as Py2.7 is EOLed for almost an year already.

That said, I have no way to know if this is working. My target REST API is Django Rest Framework, that does not honor .filter() without plugins.

Owner/maintainer, please enlighten the next steps needed here.
(and thanks for the existing code) 